### PR TITLE
Fixing usage of the ou argument and skipping objects without dnshostname property 

### DIFF
--- a/SharpShares/Utilities/LDAP.cs
+++ b/SharpShares/Utilities/LDAP.cs
@@ -183,13 +183,10 @@ namespace SharpShares.Utilities
                         if (!String.IsNullOrEmpty(arguments.ou))
                         {
                             directoryEntry = "LDAP://" + arguments.ou;//OU=Domain Controllers,DC=example,DC=local";
-
                         }
                         else
                         {
-
                         directoryEntry = $"GC://{arguments.dc}/DC={arguments.domain.Replace(".", ",DC=")}";
-
                         }
                         Console.WriteLine($"[+] Attempting to connect to Global Catalog: {directoryEntry}");
                         entry = new DirectoryEntry(directoryEntry);

--- a/SharpShares/Utilities/LDAP.cs
+++ b/SharpShares/Utilities/LDAP.cs
@@ -179,7 +179,18 @@ namespace SharpShares.Utilities
                 {
                     try
                     {
-                        string directoryEntry = $"GC://{arguments.dc}/DC={arguments.domain.Replace(".", ",DC=")}";
+                        string directoryEntry = "";
+                        if (!String.IsNullOrEmpty(arguments.ou))
+                        {
+                            directoryEntry = "LDAP://" + arguments.ou;//OU=Domain Controllers,DC=example,DC=local";
+
+                        }
+                        else
+                        {
+
+                        directoryEntry = $"GC://{arguments.dc}/DC={arguments.domain.Replace(".", ",DC=")}";
+
+                        }
                         Console.WriteLine($"[+] Attempting to connect to Global Catalog: {directoryEntry}");
                         entry = new DirectoryEntry(directoryEntry);
                         mySearcher = new DirectorySearcher(entry);
@@ -206,8 +217,12 @@ namespace SharpShares.Utilities
                 mySearcher.PageSize = int.MaxValue;
                 foreach (SearchResult resEnt in mySearcher.FindAll())
                 {
-                    string ComputerName = resEnt.Properties["dnshostname"][0].ToString();
-                    ComputerNames.Add(ComputerName);
+                    if (resEnt.Properties.Contains("dnshostname"))
+                    {
+                        string ComputerName = resEnt.Properties["dnshostname"][0].ToString();
+                        ComputerNames.Add(ComputerName);
+                    }
+
                 }
                 Console.WriteLine("[+] OU Search Results: {0}", ComputerNames.Count().ToString());
                 mySearcher.Dispose();


### PR DESCRIPTION
Firstly, when dc and domain arguments are used, the OU argument is not used at all. Added a small check to use the ou argument regardless of dc and/or domain arguments.

Secondly, the tool fails when it encounters an object without dnshostname property. Added a check to see if an object has the dnshostname property. If not, it is skipped.